### PR TITLE
Deploy Minigun over Tailscale

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,39 +1,35 @@
-name: Deploy to Amazon Linux EC2
+name: Deploy Minigun
 
 on:
   workflow_dispatch:
   push:
     branches:
-      - "**"
+      - main
+
+concurrency:
+  group: minigun-production
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        
-      - name: Set outputs
-        id: vars
-        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Set up .NET Core
+      - name: Set up .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: "11.0.100-preview.4.26230.115"
-          dotnet-quality: "preview"
+          dotnet-quality: preview
 
-      - name: Install bun
+      - name: Install Bun
         uses: oven-sh/setup-bun@v2
 
-      - name: Template appsettings.json
-        run: |
-          sed -i 's|#{RAYGUN_API_KEY}|'"$RAYGUN_API_KEY"'|g' src/Minigun/appsettings.json
-        env:
-          RAYGUN_API_KEY: ${{ secrets.RAYGUN_API_KEY }}
-
-      - name: Publish .NET Core app
+      - name: Publish application
         run: >
           dotnet publish src/Minigun/Minigun.csproj
           -c Release
@@ -44,74 +40,58 @@ jobs:
           -p:PublishSingleFile=true
           -p:IncludeNativeLibrariesForSelfExtract=true
 
-      - name: Stop Application on EC2
+      - name: Package release
+        run: tar -C publish -czf "minigun-${GITHUB_SHA}.tar.gz" .
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: minigun-${{ github.sha }}
+          path: minigun-${{ github.sha }}.tar.gz
+          if-no-files-found: error
+          retention-days: 3
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      TAILSCALE_HOST: minigun-prod
+
+    steps:
+      - name: Download release artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: minigun-${{ github.sha }}
+
+      - name: Connect to the tailnet
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
+          audience: ${{ vars.TS_AUDIENCE }}
+          tags: tag:minigun-ci
+
+      - name: Upload and activate release
         env:
-          EC2_HOST: ${{ secrets.EC2_HOST }}
-          EC2_USER: ${{ secrets.EC2_USER }}
-          EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
+          RELEASE_ID: ${{ github.sha }}
         run: |
-          echo "$EC2_SSH_KEY" > ./ec2_key.pem
-          chmod 600 ./ec2_key.pem
+          set -Eeuo pipefail
+          archive="minigun-${RELEASE_ID}.tar.gz"
+          remote_archive="/var/lib/minigun-deploy/uploads/${archive}"
 
-          # Disable host key checking
-          mkdir -p ~/.ssh
-          echo -e "Host *\n\tStrictHostKeyChecking no" > ~/.ssh/config
+          tailscale ssh "minigun-deploy@${TAILSCALE_HOST}" \
+            "umask 077 && cat > '${remote_archive}'" < "${archive}"
+          tailscale ssh "minigun-deploy@${TAILSCALE_HOST}" \
+            "sudo /usr/local/sbin/minigun-deploy-release '${RELEASE_ID}'"
 
-          ssh -i ./ec2_key.pem $EC2_USER@$EC2_HOST << 'EOF'
-            sudo systemctl stop minigun || true
-          EOF
-
-          sleep 2
-
-      - name: Prepare deployment directory on EC2
-        env:
-          EC2_HOST: ${{ secrets.EC2_HOST }}
-          EC2_USER: ${{ secrets.EC2_USER }}
-          DEPLOY_DIR: /var/www/minigun
-        run: |
-          ssh -i ./ec2_key.pem $EC2_USER@$EC2_HOST "sudo mkdir -p '$DEPLOY_DIR' && sudo chown -R '$EC2_USER' '$DEPLOY_DIR' && sudo chmod 755 '$DEPLOY_DIR'"
-
-      - name: Upload files to EC2
-        env:
-          EC2_HOST: ${{ secrets.EC2_HOST }}
-          EC2_USER: ${{ secrets.EC2_USER }}
-          EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
-          DEPLOY_DIR: /var/www/minigun
-        run: |
-          # Upload files to EC2
-          scp -i ./ec2_key.pem -r ./publish/* $EC2_USER@$EC2_HOST:$DEPLOY_DIR/
-
-          # Upload systemd unit file and install it
-          scp -i ./ec2_key.pem ./deploy/minigun.service $EC2_USER@$EC2_HOST:/tmp/minigun.service
-          ssh -i ./ec2_key.pem $EC2_USER@$EC2_HOST << 'EOF'
-            sudo mv /tmp/minigun.service /etc/systemd/system/minigun.service
-            sudo chown root:root /etc/systemd/system/minigun.service
-            sudo chmod 644 /etc/systemd/system/minigun.service
-            sudo systemctl daemon-reload
-            sudo systemctl enable minigun
-          EOF
-          
-      - name: Create Raygun Deployment
+      - name: Record Raygun deployment
         uses: MindscapeHQ/raygun-deployments-action@v1
         with:
           personal-access-token: ${{ secrets.RAYGUN_PAT }}
           api-key: ${{ secrets.RAYGUN_API_KEY }}
-          version: ${{ steps.vars.outputs.sha_short }}
+          version: ${{ github.sha }}
           comment: ${{ github.event.head_commit.message || format('Manual deployment for {0}', github.sha) }}
-
-      - name: Start Application on EC2
-        env:
-          EC2_HOST: ${{ secrets.EC2_HOST }}
-          EC2_USER: ${{ secrets.EC2_USER }}
-          EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
-          DEPLOY_DIR: /var/www/minigun
-        run: |
-          ssh -i ./ec2_key.pem $EC2_USER@$EC2_HOST << EOF
-            set -x
-
-            sudo systemctl start minigun
-            sudo systemctl status minigun --no-pager
-          EOF
-
-      - name: Clean up
-        run: rm -f ./ec2_key.pem

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,8 @@ jobs:
       - name: Set up .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "10.0.x"
+          dotnet-version: "11.0.100-preview.4.26230.115"
+          dotnet-quality: "preview"
 
       - name: Install bun
         uses: oven-sh/setup-bun@v2

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
+        <TargetFramework>net11.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,153 @@
+# Minigun deployments
+
+Minigun is deployed as an immutable, versioned release over Tailscale SSH.
+GitHub Actions builds the application, uploads one archive, and asks the server
+to activate it. The server retains the five newest releases.
+
+## Server layout
+
+- `/opt/minigun/releases/<git-sha>` contains immutable releases.
+- `/opt/minigun/current` points to the active release.
+- `/etc/minigun/minigun.env` contains runtime secrets and is readable only by
+  root.
+- `/var/lib/minigun-deploy/uploads` is the deployment account's private upload
+  directory.
+- `/usr/local/sbin/minigun-deploy-release` validates, activates, health-checks,
+  and rolls back releases.
+
+## Tailnet policy
+
+Define both tags before assigning `tag:minigun-prod` to the server or starting
+the GitHub Actions integration. Merge these sections into the existing policy;
+do not duplicate top-level keys.
+
+```json
+{
+  "tagOwners": {
+    "tag:minigun-prod": ["autogroup:admin"],
+    "tag:minigun-ci": ["autogroup:admin"]
+  },
+  "grants": [
+    {
+      "src": ["tag:minigun-ci"],
+      "dst": ["tag:minigun-prod"],
+      "ip": ["tcp:22"]
+    }
+  ],
+  "ssh": [
+    {
+      "action": "accept",
+      "src": ["tag:minigun-ci"],
+      "dst": ["tag:minigun-prod"],
+      "users": ["minigun-deploy"]
+    },
+    {
+      "action": "check",
+      "src": ["autogroup:member"],
+      "dst": ["tag:minigun-prod"],
+      "users": ["ec2-user"]
+    }
+  ]
+}
+```
+
+An existing allow-all grant can give `tag:minigun-ci` more access than the
+grant above suggests. Review or replace broad grants before enabling the CI
+identity.
+
+After saving the policy, tag the server:
+
+```bash
+sudo tailscale up \
+  --ssh \
+  --hostname=minigun-prod \
+  --advertise-tags=tag:minigun-prod
+```
+
+## GitHub workload identity
+
+Create an OpenID Connect credential on the Tailscale **Trust credentials**
+page with:
+
+- Issuer: GitHub Actions
+- Subject: `repo:ProRedCat/minigun:environment:production`
+- Scope: `auth_keys` with write access
+- Tag: `tag:minigun-ci`
+
+Store the generated, non-secret values as `production` environment variables:
+
+```bash
+gh variable set TS_OAUTH_CLIENT_ID --env production --repo ProRedCat/minigun
+gh variable set TS_AUDIENCE --env production --repo ProRedCat/minigun
+```
+
+The workflow requests a GitHub OIDC token and creates an ephemeral Tailscale
+node for each deployment. No reusable Tailscale or SSH credential is stored in
+GitHub.
+
+## HTTPS certificates
+
+TLS is configured separately from application releases. The setup script
+installs Certbot when needed, obtains the initial certificate using the
+standalone HTTP-01 challenge, and installs the twice-daily renewal schedule.
+
+DNS must already point `minigun.proredcat.xyz` to the server and public TCP port
+80 must be open before obtaining the initial certificate:
+
+```bash
+sudo ./deploy/setup-certificates.sh you@example.com
+```
+
+The email argument is required only when obtaining the first certificate. On an
+already configured server, run the script without an argument to install or
+refresh the scheduler and deployment hook.
+
+The renewal job runs at midnight and midday UTC. After a certificate is
+successfully renewed, Certbot restarts Minigun so Kestrel loads the new
+certificate. Routine checks that do not renew a certificate do not restart the
+application.
+
+Test the HTTP-01 renewal path after provisioning:
+
+```bash
+sudo certbot renew --dry-run
+```
+
+## Server bootstrap
+
+The idempotent bootstrap creates the deployment account, directories, systemd
+unit, restricted sudo rule, and release command. On a brand-new server the
+service remains stopped until the first artifact is deployed.
+
+```bash
+sudo ./deploy/bootstrap-server.sh
+```
+
+Create the root-only runtime configuration before the first deployment:
+
+```bash
+sudo install -d -o root -g root -m 0700 /etc/minigun
+read -rsp "Raygun API key: " raygun_key && echo
+printf 'Serilog__WriteTo__1__Args__applicationKey=%s\n' "$raygun_key" \
+  | sudo tee /etc/minigun/minigun.env >/dev/null
+unset raygun_key
+sudo chown root:root /etc/minigun/minigun.env
+sudo chmod 0600 /etc/minigun/minigun.env
+```
+
+## Recovery
+
+SSM remains the break-glass access path. To activate a retained release:
+
+```bash
+release=/opt/minigun/releases/<git-sha>
+sudo ln -s "$release" /opt/minigun/current.manual
+sudo mv -Tf /opt/minigun/current.manual /opt/minigun/current
+sudo systemctl restart minigun
+curl --fail --resolve minigun.proredcat.xyz:443:127.0.0.1 \
+  https://minigun.proredcat.xyz/ --output /dev/null
+```
+
+Do not remove public SSH access or the old GitHub EC2 secrets until a deployment
+from a tagged GitHub Actions runner has completed successfully and SSM recovery
+has been retested.

--- a/deploy/bootstrap-server.sh
+++ b/deploy/bootstrap-server.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+readonly SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+readonly RELEASE_ROOT="/opt/minigun/releases"
+readonly CURRENT_LINK="/opt/minigun/current"
+readonly ENV_FILE="/etc/minigun/minigun.env"
+readonly SERVICE_FILE="/etc/systemd/system/minigun.service"
+readonly DEPLOY_COMMAND="/usr/local/sbin/minigun-deploy-release"
+
+fail() {
+  echo "minigun bootstrap: $*" >&2
+  exit 1
+}
+
+[[ ${EUID} -eq 0 ]] || fail "must run as root"
+[[ -f ${SCRIPT_DIR}/minigun.service ]] || fail "minigun.service is missing"
+[[ -f ${SCRIPT_DIR}/deploy-release.sh ]] || fail "deploy-release.sh is missing"
+
+if ! id minigun-deploy >/dev/null 2>&1; then
+  useradd --create-home --shell /bin/bash --comment "Minigun deployment account" minigun-deploy
+fi
+
+install -d -o root -g root -m 0755 /opt/minigun "${RELEASE_ROOT}"
+install -d -o root -g root -m 0700 /etc/minigun
+install -d -o minigun-deploy -g minigun-deploy -m 0700 /var/lib/minigun-deploy/uploads
+install -o root -g root -m 0755 "${SCRIPT_DIR}/deploy-release.sh" "${DEPLOY_COMMAND}"
+install -o root -g root -m 0644 "${SCRIPT_DIR}/minigun.service" "${SERVICE_FILE}"
+
+sudoers_file=$(mktemp)
+trap 'rm -f -- "${sudoers_file}"' EXIT
+printf 'minigun-deploy ALL=(root) NOPASSWD: %s *\n' "${DEPLOY_COMMAND}" > "${sudoers_file}"
+chmod 0440 "${sudoers_file}"
+visudo -cf "${sudoers_file}" >/dev/null
+install -o root -g root -m 0440 "${sudoers_file}" /etc/sudoers.d/minigun-deploy
+
+systemctl daemon-reload
+systemctl enable minigun
+
+if [[ -x ${CURRENT_LINK}/Minigun ]]; then
+  [[ -f ${ENV_FILE} ]] || fail "runtime configuration is missing: ${ENV_FILE}"
+  systemctl restart minigun
+
+  healthy=false
+  for _ in {1..30}; do
+    if curl --fail --silent --output /dev/null \
+      --resolve minigun.proredcat.xyz:443:127.0.0.1 \
+      https://minigun.proredcat.xyz/; then
+      healthy=true
+      break
+    fi
+    sleep 1
+  done
+
+  [[ ${healthy} == true ]] || fail "existing release failed its health check"
+  echo "minigun bootstrap: existing release is healthy"
+else
+  echo "minigun bootstrap: ready for the first release"
+  echo "minigun bootstrap: create ${ENV_FILE} before deploying"
+  echo "minigun bootstrap: run setup-certificates.sh before deploying"
+fi

--- a/deploy/certbot-renew.cron
+++ b/deploy/certbot-renew.cron
@@ -1,0 +1,1 @@
+0 0,12 * * * root /usr/bin/certbot renew --quiet

--- a/deploy/deploy-release.sh
+++ b/deploy/deploy-release.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+readonly APP_NAME="minigun"
+readonly RELEASE_ROOT="/opt/minigun/releases"
+readonly CURRENT_LINK="/opt/minigun/current"
+readonly UPLOAD_ROOT="/var/lib/minigun-deploy/uploads"
+readonly LOCK_FILE="/run/lock/minigun-deploy.lock"
+readonly HEALTH_HOST="minigun.proredcat.xyz"
+readonly HEALTH_URL="https://${HEALTH_HOST}/"
+readonly RELEASES_TO_KEEP=5
+
+fail() {
+  echo "minigun deploy: $*" >&2
+  exit 1
+}
+
+if [[ ${EUID} -ne 0 ]]; then
+  fail "must run as root"
+fi
+
+if [[ $# -ne 1 || ! $1 =~ ^[0-9a-f]{40}$ ]]; then
+  fail "usage: $0 <40-character git SHA>"
+fi
+
+readonly RELEASE_ID="$1"
+readonly ARCHIVE="${UPLOAD_ROOT}/minigun-${RELEASE_ID}.tar.gz"
+readonly RELEASE_DIR="${RELEASE_ROOT}/${RELEASE_ID}"
+readonly STAGING_DIR="${RELEASE_ROOT}/.${RELEASE_ID}.staging"
+
+exec 9>"${LOCK_FILE}"
+flock -n 9 || fail "another deployment is already running"
+
+[[ -f ${ARCHIVE} ]] || fail "release archive does not exist: ${ARCHIVE}"
+[[ ! -e ${RELEASE_DIR} ]] || fail "release already exists: ${RELEASE_ID}"
+
+archive_owner=$(stat -c '%U' "${ARCHIVE}")
+[[ ${archive_owner} == "minigun-deploy" ]] || fail "release archive must be owned by minigun-deploy"
+
+if tar -tzf "${ARCHIVE}" | awk '
+  /^\// { bad=1 }
+  /(^|\/)\.\.($|\/)/ { bad=1 }
+  END { exit bad ? 0 : 1 }
+'; then
+  fail "release archive contains an unsafe path"
+fi
+
+rm -rf -- "${STAGING_DIR}"
+install -d -o root -g root -m 0755 "${STAGING_DIR}"
+tar -xzf "${ARCHIVE}" --no-same-owner --no-same-permissions -C "${STAGING_DIR}"
+
+[[ -f ${STAGING_DIR}/Minigun ]] || fail "release does not contain the Minigun executable"
+chmod 0755 "${STAGING_DIR}/Minigun"
+chown -R root:root "${STAGING_DIR}"
+mv "${STAGING_DIR}" "${RELEASE_DIR}"
+rm -f -- "${ARCHIVE}"
+
+previous_release=$(readlink -f "${CURRENT_LINK}" 2>/dev/null || true)
+next_link="${CURRENT_LINK}.${RELEASE_ID}"
+ln -s "${RELEASE_DIR}" "${next_link}"
+mv -Tf "${next_link}" "${CURRENT_LINK}"
+
+rollback() {
+  echo "minigun deploy: health check failed; rolling back to ${previous_release:-<none>}" >&2
+  if [[ -n ${previous_release} && -d ${previous_release} ]]; then
+    rollback_link="${CURRENT_LINK}.rollback"
+    ln -s "${previous_release}" "${rollback_link}"
+    mv -Tf "${rollback_link}" "${CURRENT_LINK}"
+    systemctl restart "${APP_NAME}"
+  else
+    systemctl stop "${APP_NAME}" || true
+  fi
+  exit 1
+}
+
+if ! systemctl restart "${APP_NAME}"; then
+  rollback
+fi
+
+healthy=false
+for _ in {1..30}; do
+  if curl --fail --silent --output /dev/null \
+    --resolve "${HEALTH_HOST}:443:127.0.0.1" \
+    "${HEALTH_URL}"; then
+    healthy=true
+    break
+  fi
+  sleep 1
+done
+
+[[ ${healthy} == true ]] || rollback
+
+mapfile -t old_releases < <(
+  find "${RELEASE_ROOT}" -mindepth 1 -maxdepth 1 -type d ! -name '.*' -printf '%T@ %p\n' \
+    | sort -nr \
+    | awk -v keep="${RELEASES_TO_KEEP}" 'NR > keep { sub(/^[^ ]+ /, ""); print }'
+)
+
+for old_release in "${old_releases[@]}"; do
+  [[ ${old_release} == "${RELEASE_ROOT}/"* ]] || continue
+  [[ ${old_release} != "$(readlink -f "${CURRENT_LINK}")" ]] || continue
+  rm -rf -- "${old_release}"
+done
+
+echo "minigun deploy: release ${RELEASE_ID} is healthy and active"
+systemctl --no-pager --full status "${APP_NAME}"

--- a/deploy/minigun.service
+++ b/deploy/minigun.service
@@ -1,10 +1,11 @@
 [Unit]
 Description=Minigun ASP.NET Core Application
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
-WorkingDirectory=/var/www/minigun
-ExecStart=/var/www/minigun/Minigun
+WorkingDirectory=/opt/minigun/current
+ExecStart=/opt/minigun/current/Minigun
 Restart=always
 RestartSec=10
 KillSignal=SIGINT
@@ -12,6 +13,7 @@ SyslogIdentifier=minigun
 User=root
 Environment=ASPNETCORE_ENVIRONMENT=Production
 Environment=DOTNET_PRINT_TELEMETRY_MESSAGE=false
+EnvironmentFile=/etc/minigun/minigun.env
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/restart-minigun-after-certificate-renewal.sh
+++ b/deploy/restart-minigun-after-certificate-renewal.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+systemctl try-restart minigun.service

--- a/deploy/setup-certificates.sh
+++ b/deploy/setup-certificates.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+readonly SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+readonly DOMAIN="minigun.proredcat.xyz"
+readonly CERTIFICATE="/etc/letsencrypt/live/${DOMAIN}/fullchain.pem"
+readonly RENEWAL_HOOK="/etc/letsencrypt/renewal-hooks/deploy/restart-minigun"
+readonly CRON_FILE="/etc/cron.d/certbot-renew"
+
+fail() {
+  echo "minigun certificates: $*" >&2
+  exit 1
+}
+
+[[ ${EUID} -eq 0 ]] || fail "must run as root"
+[[ -f ${SCRIPT_DIR}/restart-minigun-after-certificate-renewal.sh ]] || fail "renewal hook is missing"
+[[ -f ${SCRIPT_DIR}/certbot-renew.cron ]] || fail "renewal schedule is missing"
+
+if ! command -v certbot >/dev/null 2>&1; then
+  dnf install -y certbot
+fi
+
+install -d -o root -g root -m 0755 /etc/letsencrypt/renewal-hooks/deploy
+install -o root -g root -m 0755 \
+  "${SCRIPT_DIR}/restart-minigun-after-certificate-renewal.sh" \
+  "${RENEWAL_HOOK}"
+install -o root -g root -m 0644 "${SCRIPT_DIR}/certbot-renew.cron" "${CRON_FILE}"
+systemctl enable --now crond
+
+if [[ ! -f ${CERTIFICATE} ]]; then
+  [[ $# -eq 1 && -n $1 ]] || fail "usage for a new server: $0 <certificate-contact-email>"
+  certbot certonly \
+    --standalone \
+    --non-interactive \
+    --agree-tos \
+    --email "$1" \
+    --domain "${DOMAIN}"
+fi
+
+certbot certificates --cert-name "${DOMAIN}"
+echo "minigun certificates: certificate and automatic renewal are configured"

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "11.0.100-preview.4.26230.115",
+    "rollForward": "latestFeature",
+    "allowPrerelease": true
+  }
+}


### PR DESCRIPTION
## Summary

- deploy through ephemeral GitHub Actions Tailscale identity
- activate immutable releases with health checks and automatic rollback
- provision restricted deployment, TLS renewal, and systemd configuration
- deploy only from `main` through the protected `production` environment

## Important

This branch was created from `ro/dotnet-11`, so the PR also includes the existing .NET 11 preview upgrade commit.

## Validation

- full Linux ARM64 publish succeeds
- workflow passes actionlint
- shell scripts pass syntax checks
- live release activation succeeds
- Certbot staging renewal succeeds
- tagged human Tailscale SSH succeeds